### PR TITLE
public_item-showレイアウト調整

### DIFF
--- a/app/views/public/items/_sidebar.html.erb
+++ b/app/views/public/items/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<table class="genre-table table table-bordered table-hover">
+<table class="genre-table table table-bordered table-hover shadow-lg">
   <thead class="genre-thead">
     <tr>
       <th class="active">ジャンル検索</th>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,28 +1,35 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-2 d-flex align-items-center justify-content-center">
+    <div class="col-md-2 d-flex align-items-center justify-content-center mr-5">
       <%= render "sidebar", genres: @genres %>
     </div>
-    <div class="col-md-4 offset-md-1 mt-5 mx-auto">
-      <%= image_tag @item.image, :size => '250' %>
-    </div>
-    <div class="col-md-4 offset-md-1 px-0 mt-5 mx-auto">
-      <h4><%= @item.name %></h4>
-      <h5 class="mt-3"><%= safe_join(@item.introduction.split("\n"),tag(:br)) %></h5>
-      <div class="font-weight-bold mt-3 text-nowrap">
-        ￥<%= @item.add_tax_price.to_s(:delimited) %>(税込)
-
-        <% if @item.is_active == true %>
-          <%= form_with model: @cart_item,url: cart_items_path, local: true do |f| %>
-            <%= f.hidden_field :item_id, :value => @item.id %>
-            <%= f.select :quantity, *[1..10], {include_blank: '個数選択'}, class: "mx-5 my-4" %>
-            <%= f.submit "カートに入れる", class: "btn btn-success" %>
-          <% end %>
-        <% else %>
-          <p class="text-danger font-weight-bold">売切れ</p>
-        <% end %>
+      <div class="row shadow-lg mt-5 pl-5 pt-5">
+        <div class="col-4 mx-4 my-4">
+          <%= image_tag @item.image, :size => '250' %>
+        </div>
+          <div class="col-6 mt-5 ml-4 pb-5">
+           <table class="table table-borderless">
+             <h5 class="mb-4"><%= @item.name %></h5>
+             <p class="mb-4"><%= safe_join(@item.introduction.split("\n"),tag(:br)) %></p>
+             ￥<%= @item.add_tax_price.to_s(:delimited) %>(税込)
+            <tr>
+             <th>
+               <% if @item.is_active == true %>
+               <%= form_with model: @cart_item,url: cart_items_path, local: true do |f| %>
+               <%= f.hidden_field :item_id, :value => @item.id %>
+               <%= f.select :quantity, *[1..10], {include_blank: '個数選択'}, class: "mx-4 my-4" %>
+             </th>
+             <td>
+               <%= f.submit "カートに入れる", class: "btn btn-success my-4" %>
+               <% end %>
+               <% else %>
+                 <p class="text-danger font-weight-bold">売切れ</p>
+               <% end %>
+             </td>
+            </tr>
+           </table>
+         </div>
       </div>
-    </div>
-  </div>
+   </div>
 </div>


### PR DESCRIPTION
会員側の商品詳細のレイアウト調整しました。

(報告)
商品名：約3〜10文字以内ならOK
商品説明：約24文字以内ならOK
↑
恐らく、これ以上の文字数だと表示がおかしくなります。あと、販売中の表示は大丈夫でも、売り切れの状態だと表示がおかしくなります。